### PR TITLE
feat: enhance save notification with file info and click-to-reveal in Finder

### DIFF
--- a/NeoPaste.xcodeproj/project.pbxproj
+++ b/NeoPaste.xcodeproj/project.pbxproj
@@ -429,7 +429,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = "/Users/ario/Downloads/app of paster/pasterapp/NeoPaste/Info.plist";
+				INFOPLIST_FILE = NeoPaste/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = NeoPaste;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -463,7 +463,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = "/Users/ario/Downloads/app of paster/pasterapp/NeoPaste/Info.plist";
+				INFOPLIST_FILE = NeoPaste/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = NeoPaste;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";

--- a/NeoPaste/AppDelegate.swift
+++ b/NeoPaste/AppDelegate.swift
@@ -20,7 +20,7 @@ import UserNotifications
 import os.log
 
 @MainActor
-class AppDelegate: NSObject, NSApplicationDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {
     // MARK: - Singleton
     static let shared: AppDelegate = {
         let instance = AppDelegate()
@@ -50,6 +50,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     // MARK: - Application Lifecycle
     func applicationDidFinishLaunching(_ notification: Notification) {
+        notificationCenter.delegate = self
+        
         Task { @MainActor in
             do {
                 // Initialize system settings
@@ -82,6 +84,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
         }
+    }
+    
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        return false
     }
 
     private func handlePermissionError(_ error: PermissionError) {
@@ -374,7 +380,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 let format = sender.title.replacingOccurrences(of: "Save as ", with: "").lowercased()
                 let url = try await FileSaver.shared.saveDirectly(content, format: format)
                 logger.info("Content saved successfully at: \(url.path)")
-                NotificationCenter.default.post(name: .saveCompleted, object: nil)
+                let fileName = url.lastPathComponent
+                let filePath = url.deletingLastPathComponent().path
+                NotificationCenter.default.post(name: .saveCompleted, object: nil, userInfo: ["fileName": fileName, "filePath": filePath, "fullFilePath": url.path])
             } catch {
                 // Check for file access permission errors
                 if let nsError = error as NSError?,
@@ -397,7 +405,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 let defaultFormat = content.defaultFormat
                 let url = try await FileSaver.shared.saveDirectly(content, format: defaultFormat)
                 logger.info("Content saved successfully at: \(url.path)")
-                NotificationCenter.default.post(name: .saveCompleted, object: nil)
+                let fileName = url.lastPathComponent
+                let filePath = url.deletingLastPathComponent().path
+                NotificationCenter.default.post(name: .saveCompleted, object: nil, userInfo: ["fileName": fileName, "filePath": filePath, "fullFilePath": url.path])
             } catch {
                 // Check for file access permission errors
                 if let nsError = error as NSError?,
@@ -477,5 +487,35 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         
         button.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: description)
+    }
+    
+    // MARK: - UNUserNotificationCenterDelegate
+    nonisolated func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        let userInfo = response.notification.request.content.userInfo
+        
+        if let filePath = userInfo["fullFilePath"] as? String {
+            Task { @MainActor in
+                for window in NSApp.windows {
+                    window.close()
+                }
+                
+                let script = """
+                tell application "Finder"
+                    activate
+                    set theFile to POSIX file "\(filePath)"
+                    reveal theFile
+                end tell
+                """
+                if let appleScript = NSAppleScript(source: script) {
+                    var error: NSDictionary?
+                    appleScript.executeAndReturnError(&error)
+                    if let error = error {
+                        print("AppleScript error: \(error)")
+                    }
+                }
+            }
+        }
+        
+        completionHandler()
     }
 }

--- a/NeoPaste/ClipboardMonitor.swift
+++ b/NeoPaste/ClipboardMonitor.swift
@@ -183,34 +183,36 @@ class ClipboardMonitor: ObservableObject {
     func saveCurrentContent() async throws {
         print("Attempting to save current content: \(self.currentContent)")
         
+        let savedURL: URL
+        
         switch self.currentContent {
         case .image(let image):
             logger.debug("Saving image...")
-            _ = try await fileSaver.saveWithDialog(.image(image))
+            savedURL = try await fileSaver.saveWithDialog(.image(image))
             
         case .text(let text):
             logger.debug("Saving text...")
-            _ = try await fileSaver.saveWithDialog(.text(text))
+            savedURL = try await fileSaver.saveWithDialog(.text(text))
             
         case .rtf(let data):
             logger.debug("Converting RTF to text...")
             if let attrString = try? NSAttributedString(data: data, options: [.documentType: NSAttributedString.DocumentType.rtf], documentAttributes: nil) {
-                _ = try await fileSaver.saveWithDialog(.text(attrString.string))
+                savedURL = try await fileSaver.saveWithDialog(.text(attrString.string))
             } else {
                 throw ClipboardError.conversionFailed
             }
             
         case .pdf(let data):
             logger.debug("Saving PDF...")
-            _ = try await fileSaver.saveWithDialog(.pdf(data))
+            savedURL = try await fileSaver.saveWithDialog(.pdf(data))
             
         case .file(let url):
             logger.debug("Saving file...")
-            _ = try await fileSaver.saveWithDialog(.file(url))
+            savedURL = try await fileSaver.saveWithDialog(.file(url))
             
         case .multiple(let urls):
             logger.debug("Saving multiple files...")
-            _ = try await fileSaver.saveWithDialog(.multiple(urls))
+            savedURL = try await fileSaver.saveWithDialog(.multiple(urls))
             
         case .empty:
             logger.error("Error: Clipboard is empty")
@@ -218,7 +220,9 @@ class ClipboardMonitor: ObservableObject {
         }
         
         logger.info("Save completed successfully")
-        NotificationCenter.default.post(name: .saveCompleted, object: nil)
+        let fileName = savedURL.lastPathComponent
+        let filePath = savedURL.deletingLastPathComponent().path
+        NotificationCenter.default.post(name: .saveCompleted, object: nil, userInfo: ["fileName": fileName, "filePath": filePath, "fullFilePath": savedURL.path])
     }
     
     // MARK: - Private Methods

--- a/NeoPaste/MenuBarManager.swift
+++ b/NeoPaste/MenuBarManager.swift
@@ -122,9 +122,9 @@ class MenuBarManager: NSObject, ObservableObject {
         
         NotificationCenter.default.publisher(for: .saveCompleted)
             .receive(on: RunLoop.main)
-            .sink { [weak self] _ in
+            .sink { [weak self] notification in
                 Task { @MainActor [weak self] in
-                    await self?.showSaveCompletedNotification()
+                    await self?.showSaveCompletedNotification(notification)
                 }
             }
             .store(in: &cancellables)
@@ -280,7 +280,9 @@ class MenuBarManager: NSObject, ObservableObject {
 
                 updateRecentFiles(with: savedURL.path)
                 print("Content saved successfully at: \(savedURL.path)")
-                NotificationCenter.default.post(name: .saveCompleted, object: nil)
+                let fileName = savedURL.lastPathComponent
+                let filePath = savedURL.deletingLastPathComponent().path
+                NotificationCenter.default.post(name: .saveCompleted, object: nil, userInfo: ["fileName": fileName, "filePath": filePath, "fullFilePath": savedURL.path])
             } catch {
                 print("Failed to save: \(error.localizedDescription)")
                 await showError(error)
@@ -307,7 +309,9 @@ class MenuBarManager: NSObject, ObservableObject {
 
                 updateRecentFiles(with: savedURL.path)
                 print("Content saved successfully at: \(savedURL.path)")
-                NotificationCenter.default.post(name: .saveCompleted, object: nil)
+                let fileName = savedURL.lastPathComponent
+                let filePath = savedURL.deletingLastPathComponent().path
+                NotificationCenter.default.post(name: .saveCompleted, object: nil, userInfo: ["fileName": fileName, "filePath": filePath, "fullFilePath": savedURL.path])
             } catch {
                 print("Failed to save: \(error.localizedDescription)")
                 await showError(error)
@@ -424,10 +428,21 @@ class MenuBarManager: NSObject, ObservableObject {
     }
     
     
-    private func showSaveCompletedNotification() async {
+    private func showSaveCompletedNotification(_ notification: Notification) async {
         let content = UNMutableNotificationContent()
         content.title = "Save Completed"
-        content.body = "Content saved successfully"
+        
+        if let fileName = notification.userInfo?["fileName"] as? String,
+           let filePath = notification.userInfo?["filePath"] as? String {
+            content.body = "name: \(fileName)\npath: \(filePath)"
+            
+            if let fullFilePath = notification.userInfo?["fullFilePath"] as? String {
+                content.userInfo = ["fullFilePath": fullFilePath]
+            }
+        } else {
+            content.body = "Content saved successfully"
+        }
+        
         content.sound = .default
         
         let request = UNNotificationRequest(

--- a/NeoPaste/NeoPaste.entitlements
+++ b/NeoPaste/NeoPaste.entitlements
@@ -45,9 +45,6 @@
         <string>/Documents/</string>
     </array>
     
-    <!-- Development -->
-    <key>com.apple.developer.aps-environment</key>
-    <string>development</string>
     
 
     <key>com.apple.security.automation.apple-events</key>

--- a/NeoPaste/NeoPaste.swift
+++ b/NeoPaste/NeoPaste.swift
@@ -129,7 +129,9 @@ struct NeoPaste: App {
             logger.debug("Starting clipboard save operation")
             let savedURL = try await FileSaver.shared.saveWithDialog(clipboardMonitor.currentContent)
             logger.info("Content saved successfully at: \(savedURL.path)")
-            NotificationCenter.default.post(name: .saveCompleted, object: nil)
+            let fileName = savedURL.lastPathComponent
+            let filePath = savedURL.deletingLastPathComponent().path
+            NotificationCenter.default.post(name: .saveCompleted, object: nil, userInfo: ["fileName": fileName, "filePath": filePath, "fullFilePath": savedURL.path])
         } catch {
             if case FileSavingError.userCancelled = error {
                 logger.debug("Save operation cancelled by user")

--- a/NeoPaste/NeoPasteRelease.entitlements
+++ b/NeoPaste/NeoPasteRelease.entitlements
@@ -45,9 +45,6 @@
         <string>/Documents/</string>
     </array>
     
-    <!-- Development -->
-    <key>com.apple.developer.aps-environment</key>
-    <string>development</string>
     
 
     <key>com.apple.security.automation.apple-events</key>

--- a/NeoPaste/ShortcutManager.swift
+++ b/NeoPaste/ShortcutManager.swift
@@ -142,36 +142,15 @@ class ShortcutManager: ObservableObject {
             MenuBarManager.shared.updateRecentFiles(with: savedURL.path)
 
             print("Content saved successfully at: \(savedURL.path)")
-            await showNotification(title: "Success", message: "Content saved successfully")
-            NotificationCenter.default.post(name: .saveCompleted, object: nil)
+            let fileName = savedURL.lastPathComponent
+            let filePath = savedURL.deletingLastPathComponent().path
+            NotificationCenter.default.post(name: .saveCompleted, object: nil, userInfo: ["fileName": fileName, "filePath": filePath, "fullFilePath": savedURL.path])
             
         } catch FileSavingError.userCancelled {
             print("Save operation cancelled by user")
         } catch {
             print("Error handling shortcut: \(error.localizedDescription)")
-            await showNotification(title: "Error", message: error.localizedDescription)
             NotificationCenter.default.post(name: .saveError, object: error)
-        }
-    }
-    
-    private func showNotification(title: String, message: String) async {
-        guard defaults.bool(forKey: UserDefaultsKeys.showNotifications) else { return }
-        
-        let content = UNMutableNotificationContent()
-        content.title = title
-        content.body = message
-        content.sound = .default
-        
-        let request = UNNotificationRequest(
-            identifier: UUID().uuidString,
-            content: content,
-            trigger: nil
-        )
-        
-        do {
-            try await notificationCenter.add(request)
-        } catch {
-            print("Failed to show notification: \(error.localizedDescription)")
         }
     }
     

--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ NeoPaste is  **100% free and open source**! We believe in making productivity to
 - **📋 Menu Bar Quick Access**: Toggle saving directly from the menu bar for maximum convenience
 - **💻 Code & Image Support**: Perfect for saving code snippets, screenshots, and any other clipboard content as files
 - **📂 Save Anywhere**: Choose any location on your Mac to save your snippets and images
+- 🔔 **Enhanced Save Notifications**: Notifications now display the saved file name and path, making it easy to know exactly where your file was saved.
+- 📂 **Click-to-Reveal in Finder**: Click on the save notification to instantly reveal and highlight the saved file in Finder.
+
 
 ## 🛡️ Privacy & Security
 


### PR DESCRIPTION
## Summary

This PR enhances the save notification feature to provide better user experience when saving clipboard content.

## Changes

- **Enhanced Save Notifications**: Notifications now display the saved file name and path, making it easy to know exactly where your file was saved
- **Click-to-Reveal in Finder**: Click on the save notification to instantly reveal and highlight the saved file in Finder
- **Fullscreen App Support**: Fixed issue where clicking notification in fullscreen apps would not properly show Finder
- **Removed Push Notifications capability**: Not needed for local notifications, simplifies the build process
- **Fixed Info.plist path**: Corrected absolute path to relative path in project configuration

## Technical Details

- Modified notification system to pass file information through userInfo dictionary
- Implemented UNUserNotificationCenterDelegate to handle notification clicks
- Used AppleScript to reveal files in Finder (better fullscreen support)
- Added `applicationShouldHandleReopen` to prevent unwanted window opening

## Testing

- Tested saving clipboard content (text and images)
- Verified notification displays correct file name and path
- Tested click-to-reveal in Finder from desktop and fullscreen apps
- Verified no app window opens when clicking notification~